### PR TITLE
Add type for ts

### DIFF
--- a/honeybadger-react.d.ts
+++ b/honeybadger-react.d.ts
@@ -1,0 +1,15 @@
+declare module "@honeybadger-io/react" {
+  import { Component } from "react";
+
+  interface Props {
+    honeybadger: void;
+    children: React.ReactNode;
+    ErrorComponent?: React.ReactNode | Function;
+  }
+
+  class ErrorBoundary extends Component<Props> {}
+
+  namespace ErrorBoundary {}
+
+  export = ErrorBoundary;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git+ssh://git@github.com/honeybadger-io/honeybadger-react.git"
   },
   "main": "dist/honeybadger-react.cjs.js",
+  "types": "./honeybadger-react.d.ts",
   "module": "dist/honeybadger-react.esm.js",
   "unpkg": "dist/honeybadger-react.js",
   "jsnext:main": "dist/honeybadger-react.esm.js",


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

I want to use this package for a TypeScript project, but this hasn't a `d.ts` file.
I also confirm that https://github.com/DefinitelyTyped/DefinitelyTyped hasn't `d.ts` files for this package.
I found https://github.com/honeybadger-io/honeybadger-js/blob/master/honeybadger-js.d.ts, so I want to add type definition for TypeScript to this package.

## Related PRs
Nothing.
