### PR TITLE
Proptypes bugfix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default class HoneyBadgerErrorBoundary extends Component {
   static propTypes = {
     honeybadger: PropTypes.object,
     children: PropTypes.element,
-    ErrorComponent: PropTypes.element || PropTypes.function
+    ErrorComponent: PropTypes.element || PropTypes.func
   }
 
   constructor (props) {


### PR DESCRIPTION
## Status
**READY**
## Description
While developing a custom error component, I was getting errors in the console about a PropType mismatch. I found that the PropTypes || syntax and function PropType was incorrect so I have updated them in this pull request. 

## Related PRs
None.

## Todos
- [] Changelog Entry (unreleased)

## Steps to Test or Reproduce
If you pass in a class or function as an ErrorComponent prop to the ErrorBoundary component, you will get an error message in the console about a PropType mismatch.