### PR TITLE
Fix for npm install in the example project.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@honeybadger-io/react": "link:..",
+    "@honeybadger-io/react": "file:..",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",


### PR DESCRIPTION
## Description
Changed '`link`' to '`file`' in **example/package.json** to make `npm install` work in the example project.
