### PR TITLE
Fix type declaration

### DIFF
--- a/honeybadger-react.d.ts
+++ b/honeybadger-react.d.ts
@@ -3,7 +3,7 @@ declare module "@honeybadger-io/react" {
   import Honeybadger from "@honeybadger-io/js";
 
   interface Props {
-    honeybadger: Honeybadger;
+    honeybadger: typeof Honeybadger;
     children: React.ReactNode;
     ErrorComponent?: React.ReactNode | Function;
   }


### PR DESCRIPTION
## Status
**READY**

## Description
Honeybadger is only available as a value in the type declaration of honeybadger-js.

Without this Typescript outputs the following compilation error:
> 'Honeybadger' refers to a value, but is being used as a type here. Did you mean 'typeof Honeybadger'?

The alternative option would be to fix this in the type declaration file of @honeybadger-io/js:
```d.ts
import Server from './dist/server/types/server'
import Browser from './dist/browser/types/browser'

type Honeybadger = typeof Server & typeof Browser; # This is the new type
declare const Honeybadger: Honeybadger
export = Honeybadger
```

## Related PRs
n/a

## Todos
n/a

## Steps to Test or Reproduce
1. Add @honeybadger-io/js and @honeybadger-io/react to a Typescript project
2. Run `tsc`
