### PR TITLE
Fix typescript definitions

### DIFF
--- a/honeybadger-react.d.ts
+++ b/honeybadger-react.d.ts
@@ -1,16 +1,15 @@
 declare module "@honeybadger-io/react" {
-  import { Component } from "react";
-  import Honeybadger from "@honeybadger-io/js";
+  import React from "react";
+  import BrowserClient from "@honeybadger-io/js/dist/browser/types/core/client";
+  import ServerClient from "@honeybadger-io/js/dist/server/types/core/client";
 
   interface Props {
-    honeybadger: Honeybadger;
+    honeybadger: BrowserClient & ServerClient;
     children: React.ReactNode;
     ErrorComponent?: React.ReactNode | Function;
   }
 
-  class ErrorBoundary extends Component<Props> {}
+  declare const ErrorBoundary: React.ComponentType<Props>;
 
-  namespace ErrorBoundary {}
-
-  export = ErrorBoundary;
+  export default ErrorBoundary;
 }


### PR DESCRIPTION
## Status
**READY**

## Description
This PR is for an issue on honeybadger-js: https://github.com/honeybadger-io/honeybadger-js/issues/633
After some trial and error, this appears to be the simplest solution:
- Export type definitions for `class Client` (both Server and Browser) and set that as the type of the `honeybadger` prop of `ErrorBoundary` component.

Let me know what you think.


## Related PRs
n/a

## Todos
- [x] Fix ts error when passing honeybadger client to ErrorBoundary component

## Steps to Test or Reproduce
I tested this by creating a react app with the typescript template.
I then installed the honeybadger-react package and used it as in the docs.

1.
```bash
> npx create-react-app honeybadger-react-ts-app --template typescript
> cd honeybadger-react-ts-app
> npm i "git@github.com:honeybadger-io/honeybadger-react.git#fix-ts-definitions"
```

2. Open `src/index.tsx` and do:
```javascript
import Honeybadger from '@honeybadger-io/js';
import ErrorBoundary from '@honeybadger-io/react';

const apikey = (
    process.env.REACT_APP_HONEYBADGER_API_KEY ||
    prompt('Enter the API key for your Honeybadger project:') as string
);

const honeybadgerClient = Honeybadger.configure({
    apiKey: apikey,
    environment: 'production'
})

ReactDOM.render(
    <ErrorBoundary honeybadger={honeybadgerClient}>
    <App />
    </ErrorBoundary>,
  document.getElementById('root')
);
```
