### PR TITLE
#293 Fix for source maps error with create-react-app v5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "./dist",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #293.
Generate `sourcesContent` in source maps with `inlineSources: true`.
