### PR TITLE
fix: use node 16 and npm ci in shipjs workflows

### DIFF
--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -15,11 +15,13 @@ jobs:
           fetch-depth: 0
           ref: master
       - uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
       - run: |
           if [ -f "yarn.lock" ]; then
             yarn install
           else
-            npm install
+            npm ci
           fi
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/shipjs-schedule-prepare.yml
+++ b/.github/workflows/shipjs-schedule-prepare.yml
@@ -12,11 +12,13 @@ jobs:
           fetch-depth: 0
           ref: master
       - uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
       - run: |
           if [ -f "yarn.lock" ]; then
             yarn install
           else
-            npm install
+            npm ci
           fi
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -15,12 +15,13 @@ jobs:
           ref: master
       - uses: actions/setup-node@v1
         with:
+          node-version: '16.x'
           registry-url: "https://registry.npmjs.org"
       - run: |
           if [ -f "yarn.lock" ]; then
             yarn install
           else
-            npm install
+            npm ci
           fi
       - run: npx shipjs trigger
         env:


### PR DESCRIPTION
Refs: #327

## Status
**READY**

## Description
Shipjs [fails](https://github.com/honeybadger-io/honeybadger-react/runs/6514705705?check_suite_focus=true) because it uses old version of node. Plus, it does not use `npm ci`, which means it could generate a new `package-lock.json` and it will complain that the working tree is not clean.
