### PR TITLE
chore: fix prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preversion": "npm test",
     "version": "scripts/update-versions.sh",
     "postversion": "git push && git push --tags",
-    "prepublishOnly": "npm build && npm test",
+    "prepublishOnly": "npm run build && npm test",
     "release": "shipjs prepare"
   },
   "peerDependencies": {


### PR DESCRIPTION
Refs: #327

## Status
**READY**

## Description
`npm build` does not work with node 16. Fix with `npm run build`.
